### PR TITLE
Cache NetworkComponents in ServiceLocators.kt

### DIFF
--- a/app/src/main/kotlin/codes/chrishorner/socketweather/ServiceLocators.kt
+++ b/app/src/main/kotlin/codes/chrishorner/socketweather/ServiceLocators.kt
@@ -33,7 +33,7 @@ private var networkComponents: NetworkComponents? = null
 @MainThread
 fun Context.getNetworkComponents(): NetworkComponents {
   networkComponents?.let { return it }
-  return NetworkComponents(app, getLocationChoices())
+  return NetworkComponents(app, getLocationChoices()).also { networkComponents = it }
 }
 
 private var forecaster: Forecaster? = null


### PR DESCRIPTION
When inspecting the dependency management of the app I noticed that `NetworkComponents` were not being cached.