### PR TITLE
Set app to mimic common Chrome user agent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,5 +143,6 @@ dependencies {
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
   testImplementation "app.cash.turbine:turbine:${versions.turbine}"
   testImplementation "com.google.truth:truth:${versions.truth}"
+  testImplementation "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
   coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.jdk_desugar}"
 }

--- a/app/src/debug/kotlin/codes/chrishorner/socketweather/data/DebugNetworkComponents.kt
+++ b/app/src/debug/kotlin/codes/chrishorner/socketweather/data/DebugNetworkComponents.kt
@@ -3,6 +3,7 @@ package codes.chrishorner.socketweather.data
 import android.app.Application
 import android.content.Intent
 import codes.chrishorner.socketweather.MainActivity
+import codes.chrishorner.socketweather.data.DataConfig.UserAgentInterceptor
 import codes.chrishorner.socketweather.debug.DebugEndpoint
 import codes.chrishorner.socketweather.debug.DebugPreferenceKeys.ENDPOINT
 import codes.chrishorner.socketweather.debug.DebugPreferenceKeys.HTTP_LOG_LEVEL
@@ -69,6 +70,7 @@ class DebugNetworkComponents(
 
     val httpClient: OkHttpClient = OkHttpClient.Builder()
       .addInterceptor(logger)
+      .addNetworkInterceptor(UserAgentInterceptor())
       .build()
 
     val currentEndpoint = preferenceStore.blockingGet().getEnum(ENDPOINT) ?: DebugEndpoint.MOCK

--- a/app/src/main/kotlin/codes/chrishorner/socketweather/data/DataConfig.kt
+++ b/app/src/main/kotlin/codes/chrishorner/socketweather/data/DataConfig.kt
@@ -10,6 +10,9 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
 import java.lang.reflect.Type
 import java.time.Instant
 import java.time.ZoneId
@@ -17,6 +20,18 @@ import java.time.ZoneId
 object DataConfig {
 
   const val API_ENDPOINT = "https://api.weather.bom.gov.au/v1/"
+  const val USER_AGENT_HEADER = "User-Agent"
+  const val USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+
+  class UserAgentInterceptor : Interceptor {
+    override fun intercept(chain: Chain): Response = chain.proceed(
+      chain.request()
+        .newBuilder()
+        .header(USER_AGENT_HEADER, USER_AGENT)
+        .build()
+    )
+  }
 
   val moshi: Moshi = Moshi.Builder()
     .add(InstantAdapter)

--- a/app/src/release/kotlin/codes/chrishorner/socketweather/data/ReleaseNetworkComponents.kt
+++ b/app/src/release/kotlin/codes/chrishorner/socketweather/data/ReleaseNetworkComponents.kt
@@ -1,6 +1,8 @@
 package codes.chrishorner.socketweather.data
 
+import codes.chrishorner.socketweather.data.DataConfig.UserAgentInterceptor
 import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.create
@@ -9,6 +11,11 @@ class ReleaseNetworkComponents(apiEndpoint: String, moshi: Moshi) : NetworkCompo
 
   override val api: WeatherApi = Retrofit.Builder()
     .baseUrl(apiEndpoint)
+    .client(
+      OkHttpClient.Builder()
+        .addNetworkInterceptor(UserAgentInterceptor())
+        .build()
+    )
     .addConverterFactory(EnvelopeConverter)
     .addConverterFactory(MoshiConverterFactory.create(moshi))
     .build()

--- a/app/src/test/kotlin/codes/chrishorner/socketweather/data/UserAgentInterceptorTest.kt
+++ b/app/src/test/kotlin/codes/chrishorner/socketweather/data/UserAgentInterceptorTest.kt
@@ -1,0 +1,29 @@
+package codes.chrishorner.socketweather.data
+
+import codes.chrishorner.socketweather.data.DataConfig.UserAgentInterceptor
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Test
+
+class UserAgentInterceptorTest {
+
+  private val httpClient = OkHttpClient.Builder()
+    .addNetworkInterceptor(UserAgentInterceptor())
+    .build()
+  private val server = MockWebServer()
+
+  @Test fun `http requests include custom user agent`() {
+    server.enqueue(MockResponse())
+    httpClient
+      .newCall(
+        Request.Builder()
+          .url(server.url("/"))
+          .build()
+      )
+      .execute()
+    assertThat(server.takeRequest().getHeader(DataConfig.USER_AGENT_HEADER)).isEqualTo(DataConfig.USER_AGENT)
+  }
+}


### PR DESCRIPTION
Sets a [user agent](https://developers.whatismybrowser.com/useragents/explore/software_name/chrome/) on the HTTP client via interceptor in the release variant.

Now that Socket Weather has all the must-have features I want (great job on the rain radar by the way!) I don't want the BOM to go blocking it or shutting down the API. 😬 

Resolves #23 