### PR TITLE
Update navigation library to 2.4.0-rc01

### DIFF
--- a/app/src/main/kotlin/codes/chrishorner/socketweather/Navigation.kt
+++ b/app/src/main/kotlin/codes/chrishorner/socketweather/Navigation.kt
@@ -9,8 +9,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import codes.chrishorner.socketweather.about.AboutScreen
 import codes.chrishorner.socketweather.choose_location.ChooseLocationScreen
 import codes.chrishorner.socketweather.choose_location.ChooseLocationViewModel

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       'coroutines'           : '1.5.2',
       'compose'              : '1.0.5',
       'accompanist'          : '0.20.2',
-      'navigation'           : '2.4.0-alpha06',
+      'navigation'           : '2.4.0-rc01',
       'appcompat'            : '1.3.1',
       'androidx_core'        : '1.7.0',
       'androidx_activity'    : '1.4.0',


### PR DESCRIPTION
Fixes a bug where the app becomes blank and unresponsive after entering then leaving split screen mode, as described in this issue: https://github.com/chris-horner/SocketWeather/issues/50.